### PR TITLE
Move lambda arguments to the end to match faunadb-ruby

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faunadb",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "FaunaDB (faunadb.com) client for node",
   "homepage": "https://faunadb.com",
   "repository": "faunadb/faunadb-js",

--- a/src/PageStream.js
+++ b/src/PageStream.js
@@ -46,7 +46,7 @@ export default class PageStream extends AsyncStream {
 
     let q = query.paginate(this._set, {size: this.pageSize, [this._direction]: this._cursor})
     if (this.mapLambda !== null)
-      q = query.map(this.mapLambda, q)
+      q = query.map(q, this.mapLambda)
 
     const page = Page.fromRaw(await this._client.query(q))
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -316,7 +316,7 @@ export default class Model {
 
   static async _mapPage(client, instanceSet, pageLambda, pageParams) {
     const pageQuery = query.paginate(instanceSet, pageParams)
-    const mapQuery = query.map(pageLambda, pageQuery)
+    const mapQuery = query.map(pageQuery, pageLambda)
     const page = Page.fromRaw(await client.query(mapQuery))
     return page.mapData(resource => this.getFromResource(client, resource))
   }

--- a/src/query.js
+++ b/src/query.js
@@ -41,7 +41,7 @@ let lambdaAutoVarNumber = 0
  *     // Produces: {lambda: 'auto0', expr: {add: [{var: 'auto0'}, {var: 'auto0'}]}}
  *
  * Query functions requiring lambdas can be pass raw functions without explicitly calling `lambda`.
- * For example: `query.map(a => query.add(a, 1), collection)`.
+ * For example: `query.map(collection, a => query.add(a, 1))`.
  *
  * You can also use {@link lambda_pattern}, or use {@link lambda_expr} directly.
  *
@@ -106,12 +106,12 @@ export function lambda_expr(var_name, expr) {
 }
 
 /** See the [docs](https://faunadb.com/documentation/queries#collection_functions). */
-export function map(lambda_expr, collection) {
+export function map(collection, lambda_expr) {
   return {map: toLambda(lambda_expr), collection}
 }
 
 /** See the [docs](https://faunadb.com/documentation/queries#collection_functions). */
-export function foreach(lambda_expr, collection) {
+export function foreach(collection, lambda_expr) {
   return {foreach: toLambda(lambda_expr), collection}
 }
 

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -80,62 +80,59 @@ describe('query', () => {
     const arrayLambda = query.lambda_pattern(['a', 'b'], ({a, b}) => [b, a])
     assert.deepEqual(arrayLambda, query.lambda_expr(['a', 'b'],
       [query.variable('b'), query.variable('a')]))
-    await assertQuery(query.map(arrayLambda, [[1, 2], [3, 4]]), [[2, 1], [4, 3]])
+    await assertQuery(query.map([[1, 2], [3, 4]], arrayLambda), [[2, 1], [4, 3]])
 
     const objectLambda = query.lambda_pattern({alpha: 'a', beta: 'b'}, ({a, b}) => [b, a])
     assert.deepEqual(objectLambda, query.lambda_expr({alpha: 'a', beta: 'b'},
       [query.variable('b'), query.variable('a')]))
     const objectData = query.quote([{alpha: 1, beta: 2}, {alpha: 3, beta: 4}])
-    await assertQuery(query.map(objectLambda, objectData), [[2, 1], [4, 3]])
+    await assertQuery(query.map(objectData, objectLambda), [[2, 1], [4, 3]])
 
     const mixedPattern = {alpha: ['a', 'b'], beta: {gamma: 'c', delta: 'd'}}
     const mixedLambda = query.lambda_pattern(mixedPattern, ({a, b, c, d}) => [a, b, c, d])
     assert.deepEqual(mixedLambda, query.lambda_expr(mixedPattern,
       [query.variable('a'), query.variable('b'), query.variable('c'), query.variable('d')]))
     const mixedData = query.quote([{alpha: [1, 2], beta: {gamma: 3, delta: 4}}])
-    await assertQuery(query.map(mixedLambda, mixedData), [[1, 2, 3, 4]])
+    await assertQuery(query.map(mixedData, mixedLambda), [[1, 2, 3, 4]])
 
     // Allows ignored variables.
     const ignoreLambda = query.lambda_pattern(['foo', '', 'bar'], ({foo, bar}) => [bar, foo])
     assert.deepEqual(ignoreLambda, query.lambda_expr(['foo', '', 'bar'],
       [query.variable('bar'), query.variable('foo')]))
-    await assertQuery(query.map(ignoreLambda, [[1, 2, 3], [4, 5, 6]]), [[3, 1], [6, 4]])
+    await assertQuery(query.map([[1, 2, 3], [4, 5, 6]], ignoreLambda), [[3, 1], [6, 4]])
 
     // A variable used multiple times takes on the value of the last binding.
     const dupLambda = query.lambda_pattern(['foo', '', 'foo'], ({foo}) => foo)
-    await assertQuery(query.map(dupLambda, [[1, 2, 3]]), [3])
+    await assertQuery(query.map([[1, 2, 3]], dupLambda), [3])
 
     // Extra array elements are ignored.
     const ignore_lambda = query.lambda_pattern(['a', 'b'], ({a, b}) => [a, b])
-    await assertQuery(query.map(ignore_lambda, [[1, 2, 3]]), [[1, 2]])
+    await assertQuery(query.map([[1, 2, 3]], ignore_lambda), [[1, 2]])
 
     // Object patterns must have all keys.
     await assertBadQuery(query.map(
-      query.lambda_pattern({alpha: 'a'}, () => 0),
-      [{alpha: 1, beta: 2}]))
+      [{alpha: 1, beta: 2}],
+      query.lambda_pattern({alpha: 'a'}, () => 0),))
 
     // Lambda generator fails for bad pattern.
     assert.throws(() => query.lambda_pattern({alpha: 0}, () => 0), InvalidQuery)
   })
 
   it('map', async function() {
-    await assertQuery(query.map(a => query.multiply([2, a]), [1, 2, 3]), [2, 4, 6])
+    await assertQuery(query.map([1, 2, 3], a => query.multiply([2, a])), [2, 4, 6])
     // Should work for manually constructed lambda too.
     await assertQuery(
-      query.map(
-        query.lambda_expr('a', query.multiply([2, query.variable('a')])),
-        [1, 2, 3]),
+      query.map([1, 2, 3], query.lambda_expr('a', query.multiply([2, query.variable('a')]))),
       [2, 4, 6])
 
     const page = query.paginate(nSet(1))
-    const ns = query.map(a => query.select(['data', 'n'], query.get(a)), page)
+    const ns = query.map(page, a => query.select(['data', 'n'], query.get(a)))
     assertQuery(ns, {data: [1, 1]})
   })
 
   it('foreach', async function() {
     const refs = [(await create()).ref, (await create()).ref]
-    await client.query(
-      query.foreach(query.delete_expr, refs))
+    await client.query(query.foreach(refs, query.delete_expr))
     for (const ref of refs)
       await assertQuery(query.exists(ref), false)
   })


### PR DESCRIPTION
This is a breaking change, so we might need to tell the client about this / change the version number.