### PR TITLE
Add support for the true `ref` function

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -32,9 +32,11 @@ var objectAssign = require('object-assign');
  * @return {Expr}
  */
 function Ref() {
-  arity.min(1, arguments);
-  var args = argsToArray(arguments);
-  return new (values.Ref.bind.apply(values.Ref, [null].concat(args)));
+  arity.between(1, 2, arguments);
+  switch (arguments.length) {
+    case 1: return new values.Ref(arguments[0]);
+    case 2: return new Expr({ ref: wrap(arguments[0]), id: wrap(arguments[1]) });
+  }
 }
 
 // Basic forms

--- a/src/query.js
+++ b/src/query.js
@@ -26,9 +26,11 @@ var objectAssign = require('object-assign');
 // Type helpers
 
 /**
- * Constructs a Ref value.
+ * If one parameter is provided, constructs a literal Ref value. If two are provided,
+ * constructs a Ref() function that, when evaluated, returns a Ref value.
  *
- * @param {string} ref
+ * @param {string|module:query~ExprArg} ref
+ * @param {?module:query~ExprArg} id
  * @return {Expr}
  */
 function Ref() {

--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -5,6 +5,7 @@ type ExprArg = (ExprVal|Array<ExprVal>);
 export type Lambda = (...vars: any[]) => Expr;
 
 export module query {
+  export function Ref(ref: ExprArg, id?: ExprArg): Expr;
   export function Let(vars: ExprArg, in_expr: ExprArg): Expr;
   export function Var(varName: ExprArg): Expr;
   export function If(condition: ExprArg, then: ExprArg, _else: ExprArg): Expr;

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -520,8 +520,8 @@ describe('query', function () {
   });
 
   it('ref', function() {
-    var id = refN1.id.toString();
-    return assertQuery(query.Ref(classRef, query.Concat([id.charAt(0), id.substr(1)])), refN1);
+    var ref = query.Ref(classRef.value + "/123456");
+    return assertQuery(query.Ref(classRef, query.Concat(["123", "456"])), ref);
   });
 
   // Check arity of all query functions

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -519,12 +519,17 @@ describe('query', function () {
     return Promise.all([p1, p2]);
   });
 
+  it('ref', function() {
+    var id = refN1.id.toString();
+    return assertQuery(query.Ref(classRef, query.Concat([id.charAt(0), id.substr(1)])), refN1);
+  });
+
   // Check arity of all query functions
 
   it('arity', function () {
     // By default assume all functions should have strict arity
     var testParams = {
-      'Ref': [0, 'at least 1'],
+      'Ref': [3, 'from 1 to 2'],
       'Do': [0, 'at least 1'],
       'Lambda': [3, 'from 1 to 2'],
       'Get': [3, 'from 1 to 2'],

--- a/test/util.js
+++ b/test/util.js
@@ -106,7 +106,7 @@ function unwrapExprValues(obj) {
 
 var rootClient = getClient({ secret: testConfig.auth });
 var dbName = 'faunadb-js-test-' + randomString();
-var dbRef = Ref('databases', dbName);
+var dbRef = Ref(['databases', dbName].join('/'));
 
 // global before/after for every test
 

--- a/test/util.js
+++ b/test/util.js
@@ -106,7 +106,7 @@ function unwrapExprValues(obj) {
 
 var rootClient = getClient({ secret: testConfig.auth });
 var dbName = 'faunadb-js-test-' + randomString();
-var dbRef = Ref(['databases', dbName].join('/'));
+var dbRef = Ref('databases/' + dbName);
 
 // global before/after for every test
 


### PR DESCRIPTION
I'm not sure if we should continue to have the driver internally join ref parts by `/` anymore anywhere, actually. It should probably just have the standard Ref() constructor, and the `{ ref: id: }` function form.